### PR TITLE
added http interceptor to modify headers - cache setting

### DIFF
--- a/src/app/disablecache-interceptor.service.ts
+++ b/src/app/disablecache-interceptor.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpHeaders } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DisablecacheInterceptorService implements HttpInterceptor {
+
+  intercept(req: HttpRequest<any>, next: HttpHandler) {
+    const httpRequest = req.clone({
+      headers: new HttpHeaders({
+        'Cache-Control': 'no-cache',
+        'Pragma': 'no-cache',
+        'Expires': 'Sat, 01 Jan 2000 00:00:00 GMT'
+      })
+    });
+
+    return next.handle(httpRequest);
+  }
+}


### PR DESCRIPTION
# Why is the PR required?

### New Feature:

Turn off browser caching - ensure content is always fresh

## What does this PR do?

Adds an http interceptor module that modifies all http request headers to include disabled cache setting

## How was this PR implemented?

```  json
import { Injectable } from '@angular/core';
import { HttpInterceptor, HttpRequest, HttpHandler, HttpHeaders } from '@angular/common/http';

@Injectable({
  providedIn: 'root'
})
export class DisablecacheInterceptorService implements HttpInterceptor {

  intercept(req: HttpRequest<any>, next: HttpHandler) {
    const httpRequest = req.clone({
      headers: new HttpHeaders({
        'Cache-Control': 'no-cache',
        'Pragma': 'no-cache',
        'Expires': 'Sat, 01 Jan 2000 00:00:00 GMT'
      })
    });

    return next.handle(httpRequest);
  }
}
```

## How long did it take?
10 minutes


